### PR TITLE
Add minHeight to the selector

### DIFF
--- a/assets/js/selector.js
+++ b/assets/js/selector.js
@@ -58,6 +58,7 @@ Selector = (function($, $field) {
 
         // Apply height and overflow styles to box
         self.$field.find('.input-with-items').css({
+            minHeight: '3.25em',
             maxHeight: height,
             overflowY: 'scroll'
         });


### PR DESCRIPTION
Add a `minHeight` to the selector when `size: <number>` is being used in a blueprint file. By doing so the text ‘No matching files yet.’ will be visible, without a `minHeight` the whole box collapes and only its borders are visible. The value here is hardcoded, it’s probably better to caculate it based on the `.selector-item-empty` class plus borders.
