### PR TITLE
Max-height in the selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.5.1
+
+**Bugfixes:**
+
+* More compatible way of getting the current panel language
+
 ## Version 1.5.0
 
 **Features:**

--- a/assets/css/selector.css
+++ b/assets/css/selector.css
@@ -1,18 +1,23 @@
 .selector {}
+  .selector .input-with-items {
+    max-height: 15.5em;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
 
     .selector .item-image {
         border-right: 1px solid #efefef;
     }
 
-        .selector .item-image a {
-            background: #000;
-            display: inline-block;
-            text-align: center;
-            height: 100%;
-            width: 100%;
-            line-height: 3em;
-            color: #fff;
-        }
+      .selector .item-image a {
+          background: #000;
+          display: inline-block;
+          text-align: center;
+          height: 100%;
+          width: 100%;
+          line-height: 3em;
+          color: #fff;
+      }
 
     .selector-item-selected {
         color: #fff;

--- a/selector.php
+++ b/selector.php
@@ -5,7 +5,7 @@
  *
  * Fileselect Field for Kirby 2
  *
- * @version   1.5.0
+ * @version   1.5.1
  * @author    digital storytelling pioneers <digital@storypioneers.com>
  * @author    feat. Jonas Döbertin <hello@jd-powered.net>
  * @copyright digital storytelling pioneers <digital@storypioneers.com>

--- a/selector.php
+++ b/selector.php
@@ -2,7 +2,7 @@
 
 /**
  * Selector.
- * 
+ *
  * Fileselect Field for Kirby 2
  *
  * @version   1.5.0
@@ -143,9 +143,17 @@ class SelectorField extends BaseField
      */
     public function __construct()
     {
-        // Load language files
+        // Build translation file path
         $baseDir = __DIR__ . DS . self::LANG_DIR . DS;
-        $lang    = panel()->language();
+
+        // Get panel language
+        if (version_compare(panel()->version(), '2.2', '>=')) {
+            $lang = panel()->translation()->code();
+        } else {
+            $lang = panel()->language();
+        }
+
+        // Load language files
         if (file_exists($baseDir . $lang . '.php')) {
             require $baseDir . $lang . '.php';
         } else {

--- a/template.php
+++ b/template.php
@@ -8,7 +8,7 @@
                 <div class="item-content">
                     <?php if ($file->type() == 'image'): ?>
                         <figure class="item-image">
-                            <?php if (version_compare(Kirby::version(), '2.2', '>=')): ?>
+                            <?php if (version_compare(panel()->version(), '2.2', '>=')): ?>
                                 <a class="btn btn-with-icon" data-context="<?= purl($file, 'context') ?>" href="#options" title="<?= l('pages.show.subpages.edit') ?>">
                                     <?= thumb($file, array('width' => 48, 'height' => 48, 'crop' => true)) ?>
                                 </a>
@@ -43,7 +43,7 @@
                 <nav class="item-options">
                     <ul class="nav nav-bar">
                         <li>
-                            <?php if (version_compare(Kirby::version(), '2.2', '>=')): ?>
+                            <?php if (version_compare(panel()->version(), '2.2', '>=')): ?>
                                 <a class="btn btn-with-icon" data-context="<?= purl($file, 'context') ?>" href="#options" title="<?= l('pages.show.subpages.edit') ?>">
                                     <i class="icon icon-left fa fa-pencil"></i>
                                     <span><?= l('pages.show.subpages.edit') ?></span>


### PR DESCRIPTION
I was just checking in a project using the selector, and I noticed the client threw in a ton of images, which was making the selector kind of overwhelming in the panel. I went in and gave it a max-height of 15.5em (which equates to exactly five images) with auto scrolling CSS.

Sending this over to you if you find it helpful.
