### PR TITLE
Typographical improvement

### DIFF
--- a/template.php
+++ b/template.php
@@ -33,7 +33,7 @@
                             <small class="item-meta marginalia">
                                 <?= $file->type() ?> / <?= $file->niceSize() ?>
                                 <?php if (($file->type() == 'image') and ($file->extension() != 'svg')): ?>
-                                    / <?= $file->width() ?> x <?= $file->height() ?>
+                                    / <?= $file->width() ?> &times; <?= $file->height() ?>
                                 <?php endif ?>
                             </small>
                         </div>


### PR DESCRIPTION
I changed ‘x’ into ‘×’, the correct character to be used in dimensions. 
