### PR TITLE
Adding convenient toFiles field method to simplify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,11 @@ When you're using the Selector field in Single Mode, gaining access to the full 
 
 **Multiple Mode**
 
-In multiple mode, the Selector field stores a comma-separated list of filenames, based on how many files you selected. To convert this list into a fully-featured file collection (just like `$page->files()`), you need a bit more code.
+In multiple mode, the Selector field stores a comma-separated list of filenames, based on how many files you selected. To convert this list into a fully-featured file collection (just like `$page->files()`), you just need the field method `toFiles` that comes with the plugin.
 
 ```php
-
-	// Transform the comma-separated list of filenames into a file collection
-	$filenames = $page->yourselectorfield()->split(',');
-	if(count($filenames) < 2) $filenames = array_pad($filenames, 2, '');
-	$files = call_user_func_array(array($page->files(), 'find'), $filenames);
-
-	// Use the file collection
-	foreach($files as $file)
+	// Fetch the Files collection from the field value and use it like you would $page->files()
+	foreach($page->yourselectorfield()->toFiles() as $file)
 	{
 		echo $file->url();
 	}

--- a/field-selector.php
+++ b/field-selector.php
@@ -14,3 +14,13 @@
 
 // register the builder field
 $kirby->set('field', 'selector', __DIR__ . DS . 'field');
+
+
+field::$methods['toFiles'] = function ($field) {
+    // Transform the comma-separated list of filenames into a file collection
+    $fileNames = $field->split(',');
+    // find method has special handling for finding a single file, pad file names with empty string to force it
+    // to return a Files collection
+    $fileNames = array_pad($fileNames, 2, '');
+    return $field->page()->files()->find($fileNames);
+};


### PR DESCRIPTION
It struck me as exceptionally odd, that the documentation has this fairly convoluted code example for how to convert the comma separated file names into a files collection. That is exactly the scenario for which the field class can be extended with [field methods](https://getkirby.com/docs/developer-guide/objects/fields).