### PR TITLE
Add an option to automatically select uploaded files...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.6.0
+
+**Features:**
+
+* Add support for auto selection after uploding a file using the field specific _Add_ button
+
 ## Version 1.5.2
 
 **Features:**

--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ fields:
 			- image
 ```
 
+### autoselectadd
+
+This options allows you to tell the Selector to auto select a file if the upload is initiated by clicking on the field-related _Add_ button.
+
+```yaml
+fields:
+	featured:
+		label:         Featured Image
+		type:          selector
+		mode:          single
+		sort:          filename
+		autoselectadd: true
+		types:
+			- image
+```
+
 ### filter
 
 This options allows you to set a filename filter. This can be either a simple string or a fully featured regular expression. Only files with filenames matching the filter string or regular expression will be shown in the Selector field. You may set this to any string like `background`, `.min.js` or `large` or a regular expression like `/\.((png)|(jpe?g))/i`.

--- a/field-selector.php
+++ b/field-selector.php
@@ -4,7 +4,7 @@
  *
  * Fileselect Field for Kirby 2
  *
- * @version   1.5.2
+ * @version   1.6.0
  * @author    digital storytelling pioneers <digital@storypioneers.com>
  * @author    feat. Jonas Döbertin <hello@jd-powered.net> and others (see AUTHORS)
  * @copyright digital storytelling pioneers <digital@storypioneers.com>

--- a/field/assets/js/selector.js
+++ b/field/assets/js/selector.js
@@ -3,12 +3,92 @@ Selector = (function($, $field) {
 
     var self = this;
 
-    this.$field     = $field;
-    this.$storage   = $field.find('.js-selector-storage');
-    this.$items     = $field.find('.js-selector-item');
-    this.mode       = $field.data('mode');
-    this.autoselect = $field.data('autoselect');
-    this.size       = $field.data('size');
+    this.$field        = $field;
+    this.$storage      = $field.find('.js-selector-storage');
+    this.$items        = $field.find('.js-selector-item');
+    this.mode          = $field.data('mode');
+    this.autoselect    = $field.data('autoselect');
+    this.autoselectadd = $field.data('autoselectadd');
+    this.size          = $field.data('size');
+    this.form          = $field.parents('.form');
+
+    // Ascii conversion table. Taken from Kirby
+    // URL: https://github.com/getkirby/toolkit/blob/0ceeb44186ec0e34e45e283ddf0f99a00c192ba9/lib/f.php#L17-L121
+    this.ascii = {
+        '/Ä/g': 'Ae',
+        '/æ|ǽ|ä/g': 'ae',
+        '/À|Á|Â|Ã|Å|Ǻ|Ā|Ă|Ą|Ǎ|А/g': 'A',
+        '/à|á|â|ã|å|ǻ|ā|ă|ą|ǎ|ª|а/g': 'a',
+        '/Б/g': 'B',
+        '/б/g': 'b',
+        '/Ç|Ć|Ĉ|Ċ|Č|Ц/g': 'C',
+        '/ç|ć|ĉ|ċ|č|ц/g': 'c',
+        '/Ð|Ď|Đ/g': 'Dj',
+        '/ð|ď|đ/g': 'dj',
+        '/Д/g': 'D',
+        '/д/g': 'd',
+        '/È|É|Ê|Ë|Ē|Ĕ|Ė|Ę|Ě|Е|Ё|Э/g': 'E',
+        '/è|é|ê|ë|ē|ĕ|ė|ę|ě|е|ё|э/g': 'e',
+        '/Ф/g': 'F',
+        '/ƒ|ф/g': 'f',
+        '/Ĝ|Ğ|Ġ|Ģ|Г/g': 'G',
+        '/ĝ|ğ|ġ|ģ|г/g': 'g',
+        '/Ĥ|Ħ|Х/g': 'H',
+        '/ĥ|ħ|х/g': 'h',
+        '/Ì|Í|Î|Ï|Ĩ|Ī|Ĭ|Ǐ|Į|İ|И/g': 'I',
+        '/ì|í|î|ï|ĩ|ī|ĭ|ǐ|į|ı|и/g': 'i',
+        '/Ĵ|Й/g': 'J',
+        '/ĵ|й/g': 'j',
+        '/Ķ|К/g': 'K',
+        '/ķ|к/g': 'k',
+        '/Ĺ|Ļ|Ľ|Ŀ|Ł|Л/g': 'L',
+        '/ĺ|ļ|ľ|ŀ|ł|л/g': 'l',
+        '/М/g': 'M',
+        '/м/g': 'm',
+        '/Ñ|Ń|Ņ|Ň|Н/g': 'N',
+        '/ñ|ń|ņ|ň|ŉ|н/g': 'n',
+        '/Ö/g': 'Oe',
+        '/œ|ö/g': 'oe',
+        '/Ò|Ó|Ô|Õ|Ō|Ŏ|Ǒ|Ő|Ơ|Ø|Ǿ|О/g': 'O',
+        '/ò|ó|ô|õ|ō|ŏ|ǒ|ő|ơ|ø|ǿ|º|о/g': 'o',
+        '/П/g': 'P',
+        '/п/g': 'p',
+        '/Ŕ|Ŗ|Ř|Р/g': 'R',
+        '/ŕ|ŗ|ř|р/g': 'r',
+        '/Ś|Ŝ|Ş|Ș|Š|С/g': 'S',
+        '/ś|ŝ|ş|ș|š|ſ|с/g': 's',
+        '/Ţ|Ț|Ť|Ŧ|Т/g': 'T',
+        '/ţ|ț|ť|ŧ|т/g': 't',
+        '/Ü/g': 'Ue',
+        '/ü/g': 'ue',
+        '/Ù|Ú|Û|Ũ|Ū|Ŭ|Ů|Ű|Ų|Ư|Ǔ|Ǖ|Ǘ|Ǚ|Ǜ|У/g': 'U',
+        '/ù|ú|û|ũ|ū|ŭ|ů|ű|ų|ư|ǔ|ǖ|ǘ|ǚ|ǜ|у/g': 'u',
+        '/В/g': 'V',
+        '/в/g': 'v',
+        '/Ý|Ÿ|Ŷ|Ы/g': 'Y',
+        '/ý|ÿ|ŷ|ы/g': 'y',
+        '/Ŵ/g': 'W',
+        '/ŵ/g': 'w',
+        '/Ź|Ż|Ž|З/g': 'Z',
+        '/ź|ż|ž|з/g': 'z',
+        '/Æ|Ǽ/g': 'AE',
+        '/ß/g': 'ss',
+        '/Ĳ/g': 'IJ',
+        '/ĳ/g': 'ij',
+        '/Œ/g': 'OE',
+        '/Ч/g': 'Ch',
+        '/ч/g': 'ch',
+        '/Ю/g': 'Ju',
+        '/ю/g': 'ju',
+        '/Я/g': 'Ja',
+        '/я/g': 'ja',
+        '/Ш/g': 'Sh',
+        '/ш/g': 'sh',
+        '/Щ/g': 'Shch',
+        '/щ/g': 'shch',
+        '/Ж/g': 'Zh',
+        '/ж/g': 'zh'
+    };
 
     /**
      * Initialize fileselect field
@@ -48,6 +128,19 @@ Selector = (function($, $field) {
          */
         if(self.autoselect != 'none') {
             self.doAutoSelect();
+        }
+
+        /**
+         * Auto select an item after upload
+         *
+         * @since 1.6.0
+         */
+        if(this.autoselectadd != 'none') {
+            $field
+                .siblings()
+                .children()
+                .first()
+                .on('click', this.handleClickEventAdd.bind(this));
         }
     };
 
@@ -166,6 +259,73 @@ Selector = (function($, $field) {
     };
 
     /**
+     * Handle the click event for the field-related _Add_ button
+     *
+     * @since 1.6.0
+     */
+    this.handleClickEventAdd = function() {
+        // Listen to the change event once and hook into the upload loop
+        $('input[type=file]').one('change', function() {
+            // Update hidden field
+            if (self.single) {
+                self.$storage.val(self.sanitize(this.files[0].name));
+            } else {
+                var files = self.updateStorage();
+
+                for (var i = 0; i < this.files.length; i++) {
+                    files.push(self.sanitize(this.files[i].name));
+                }
+
+                self.$storage.val(files.join());
+            }
+
+            // Force form saving
+            self.form.submit();
+        });
+        return false;
+    }
+
+
+    /**
+     * Sanitize file names just like Kirby does
+     *
+     * @description https://github.com/getkirby/toolkit/blob/0ceeb44186ec0e34e45e283ddf0f99a00c192ba9/lib/f.php#L804-L809
+     *
+     * @since 1.6.0
+     *
+     * @param str
+     */
+    this.sanitize = function(str) {
+        var separator = '-';
+        var allowed = 'a-z0-9@._-';
+
+        // Trim and lower string
+        str = str.trim().toLowerCase();
+
+        // Convert into ascii representation
+        var asciiKeys = Object.keys(self.ascii);
+        for (var i = 0; i < asciiKeys.length; i++) {
+            str = str.replace(asciiKeys[i], self.ascii[asciiKeys[i]]);
+        }
+
+        // replace spaces with simple dashes
+        str = str.replace(new RegExp('[^' + allowed + ']', 'g'), separator);
+
+        // remove double separators
+        str = str.replace(new RegExp('[' + separator + ']{2,}', 'g'), separator);
+
+        // trim trailing and leading dashes
+        var regLeading = new RegExp('^' + separator + '+');
+        var regTrailing = new RegExp(separator + '+$');
+        str = str.replace(regLeading, '').replace(regTrailing, '');
+
+        // replace slashes with dashes
+        str = str.replace('/', separator);
+
+        return str;
+    }
+
+    /**
      * Set all items into the unselected state
      *
      * @since 1.0.0
@@ -256,6 +416,8 @@ Selector = (function($, $field) {
 
         // Set string representation of the result as storage value
         self.$storage.val(files.join());
+
+        return files;
     };
 
     return this.init();

--- a/field/selector.php
+++ b/field/selector.php
@@ -66,6 +66,14 @@ class SelectorField extends BaseField
     protected $autoselect = 'none';
 
     /**
+     * Autoselect a file after use the field specific add button.
+     *
+     * @var string
+     * @since 1.6.0
+     */
+    protected $autoselectadd = 'none';
+
+    /**
      * Filename filter.
      *
      * @var bool|string
@@ -127,6 +135,10 @@ class SelectorField extends BaseField
             'first',
             'last',
             'all',
+        ),
+        'autoselectadd' => array(
+            'none',
+            'true',
         ),
     );
 
@@ -201,6 +213,12 @@ class SelectorField extends BaseField
             case 'autoselect':
                 if (!in_array($value, $this->validValues['autoselect'])) {
                     $this->autoselect = 'none';
+                }
+                break;
+
+            case 'autoselectadd':
+                if (!in_array($value, $this->validValues['autoselectadd'])) {
+                    $this->autoselectadd = 'none';
                 }
                 break;
 
@@ -286,13 +304,14 @@ class SelectorField extends BaseField
         $wrapper = new Brick('div');
         $wrapper->addClass('selector');
         $wrapper->data(array(
-            'field'      => 'selector',
-            'name'       => $this->name(),
-            'page'       => $this->page(),
-            'mode'       => $this->mode,
-            'autoselect' => $this->autoselect(),
-            'size'       => $this->size,
-            'editable'   => $this->editable,
+            'field'         => 'selector',
+            'name'          => $this->name(),
+            'page'          => $this->page(),
+            'mode'          => $this->mode,
+            'autoselect'    => $this->autoselect(),
+            'autoselectadd' => $this->autoselectadd(),
+            'size'          => $this->size,
+            'editable'      => $this->editable,
         ));
         $wrapper->html(tpl::load(__DIR__ . DS . 'template.php', array('field' => $this)));
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "field-selector",
   "description": "Kirby file selection field",
   "author": "digital storytelling pioneers <https://github.com/storypioneers>",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "type": "kirby-plugin",
   "license": "GNU GPL v3.0 <http://opensource.org/licenses/GPL-3.0>",
   "repository": {


### PR DESCRIPTION
...when they have been uploaded using the **+ Add** button next to the Selector field's label.

I extended the JS code to listen to changes of the file input field once when `autoselectadd` is set to `true`. The JS code basically parses out the name of the files to be uploaded and manipulates the value of the hidden `$storage` field. The final step is to programmatically submit the nearest html form such that the selection is saved. I've tested it with Kirby `v2.5.2` and it works fine for single and multi Selector fields.

The biggest chunk was extracted from Kirby itself, namely the file name sanitizing function.